### PR TITLE
Reseptihaku pää/ala kategorian mukaan

### DIFF
--- a/backend/src/repositories/RecipeRepository.ts
+++ b/backend/src/repositories/RecipeRepository.ts
@@ -105,7 +105,10 @@ class RecipeRepository {
       SELECT DISTINCT recipes.* FROM recipes
       LEFT JOIN recipe_ingredients ON recipes.id = recipe_ingredients.recipe_id
       LEFT JOIN ingredients ON recipe_ingredients.ingredient_id = ingredients.id
-      WHERE recipes.title ILIKE $1 OR ingredients.name ILIKE $1
+      WHERE recipes.title ILIKE $1 
+        OR ingredients.name ILIKE $1
+        OR recipes.category ILIKE $1
+        OR recipes.secondary_category ILIKE $1
     `;
     const result = await pool.query(query, [`%${searchTerm}%`]);
     return result.rows;

--- a/frontend/src/Components/CategorySelection/CategorySelection.tsx
+++ b/frontend/src/Components/CategorySelection/CategorySelection.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import axios from "axios";
+import { SEARCH_RESULTS } from "../../Constants/routes";
+
+const categories = [
+  "Alkupalat",
+  "Pääruoat",
+  "Jälkiruoat",
+  "Juomat",
+  "Keitot",
+  "Pastat ja nuudelit",
+  "Pizzat",
+  "Makeat leivonnaiset",
+  "Kastikkeet ja marinadit",
+  "Välipalat",
+  "Salaatit",
+  "Leivät ja sämpylät",
+  "Suolaiset leivonnaiset",
+  "Lisukkeet",
+  "Säilöntä",
+  "Vauvan ruoka",
+];
+
+const secondaryCategories = [
+  "Gluteeniton",
+  "Kasvisruoka",
+  "Vegaaninen",
+  "Maidoton",
+  "Keto",
+  "Vähähiilihydraattinen",
+];
+
+const CategorySelection = () => {
+  const navigate = useNavigate();
+
+  const handleCategoryClick = async (category: string) => {
+    try {
+      const response = await axios.get(
+        `${
+          process.env.REACT_APP_API_BASE_URL
+        }/search?query=${encodeURIComponent(category)}`
+      );
+      navigate(SEARCH_RESULTS, { state: { recipes: response.data } });
+    } catch (error) {
+      console.error("Error fetching recipes:", error);
+    }
+  };
+
+  return (
+    <div>
+      <h2>Etsi kategorian mukaan</h2>
+      <div>
+        {[...categories, ...secondaryCategories].map((category) => (
+          <button key={category} onClick={() => handleCategoryClick(category)}>
+            {category}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default CategorySelection;

--- a/frontend/src/Components/RecipeSearch/RecipeSearch.tsx
+++ b/frontend/src/Components/RecipeSearch/RecipeSearch.tsx
@@ -36,11 +36,6 @@ function RecipeSearch() {
         <button type="submit">Hae</button>
       </form>
       {error && <p>{error}</p>}
-      <ul>
-        {recipes.map((recipe) => (
-          <li key={recipe.id}>{recipe.title}</li>
-        ))}
-      </ul>
     </div>
   );
 }

--- a/frontend/src/Pages/Frontpage/frontpage.tsx
+++ b/frontend/src/Pages/Frontpage/frontpage.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import RecipeSearch from "../../Components/RecipeSearch/RecipeSearch";
 import RandomRecipeButton from "../../Components/RandomRecipeButton/RandomRecipeButton";
+import CategorySelection from "../../Components/CategorySelection/CategorySelection";
 
 function Frontpage() {
   return (
@@ -11,6 +12,7 @@ function Frontpage() {
       </p>
       <RecipeSearch />
       <RandomRecipeButton />
+      <CategorySelection />
     </div>
   );
 }

--- a/frontend/src/Pages/RecipeSearchResults/RecipeSearchResults.tsx
+++ b/frontend/src/Pages/RecipeSearchResults/RecipeSearchResults.tsx
@@ -1,5 +1,6 @@
 import { useLocation, Link } from "react-router-dom";
 import { RecipeState } from "../../Types/types";
+import { LANDING } from "../../Constants/routes";
 
 interface ExtendedRecipeState extends RecipeState {
   id: number;
@@ -12,8 +13,15 @@ const SearchResultsPage = () => {
     | { recipes: ExtendedRecipeState[] }
     | undefined;
 
-  if (!state || !state.recipes) {
-    return <div>No recipes found.</div>;
+  if (!state || !state.recipes || state.recipes.length === 0) {
+    return (
+      <div>
+        <p>Reseptejä ei löytynyt!</p>
+        <Link to={LANDING}>
+          <button>Palaa etusivulle</button>
+        </Link>
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
Closes #31

Backend
- /search-endpointia on päivitetty niin, että se tukee reseptien hakua myös pää- ja alakategorian perusteella.

Frontend
- Lisätty uusi komponentti, joka listaa kaikki kategoriat painikkeina.
  - Painikkeita klikkaamalla käyttäjä ohjataan RecipeSearchResults.tsx-sivulle, jossa näytetään valitun kategorian reseptit.
- Poistettu turhaa koodia RecipeSearch.tsx-tiedostosta.
- Korjattu RecipeSearchResults.tsx-tiedoston logiikka, joka tarkistaa, löytyykö reseptejä haulle.