### PR TITLE
RecipePicture muutokset

### DIFF
--- a/frontend/src/Redux/recipeSlice.ts
+++ b/frontend/src/Redux/recipeSlice.ts
@@ -11,6 +11,7 @@ const initialState: RecipeState = {
   instructions: "",
   picture_url: "",
   user_id: "",
+  previewUrl: null,
 };
 
 const recipeSlice = createSlice({
@@ -44,6 +45,9 @@ const recipeSlice = createSlice({
     setuser_id: (state, action: PayloadAction<string>) => {
       state.user_id = action.payload;
     },
+    setPreviewUrl: (state, action: PayloadAction<string | null>) => {
+      state.previewUrl = action.payload;
+    },
     resetState: (state) => {
       state.title = "";
       state.category = "";
@@ -54,6 +58,7 @@ const recipeSlice = createSlice({
       state.instructions = "";
       state.picture_url = "";
       state.user_id = "";
+      state.previewUrl = null;
     },
   },
 });
@@ -68,6 +73,7 @@ export const {
   setInstructions,
   setpicture_url,
   setuser_id,
+  setPreviewUrl,
   resetState,
 } = recipeSlice.actions;
 

--- a/frontend/src/Types/types.tsx
+++ b/frontend/src/Types/types.tsx
@@ -10,6 +10,7 @@ export interface RecipeState {
   user_id: string;
   picture_url: string;
   nickname?: string;
+  previewUrl: string | null;
 }
 
 export interface Ingredient {


### PR DESCRIPTION
Closes #83

- Päivitetty RecipePicture-komponentti siten, että valittu kuva tallennetaan paikalliseen tilaan ja Redux-tilaan. Tämä estää kuvan lataamisen tietokantaan ennen kuin käyttäjä on valmis lähettämään reseptin palvelimelle.
  - Kuva lähetetään nyt yhdessä muun datan kanssa PictureOverview-tiedostossa.
  - Tämä parantaa suorituskykyä ja vähentää kuormitusta.
 
- Käyttäjä voi lisätä kuvan klikkaamalla laatikkoa ja poistaa kuvan klikkaamalla kuvaa, jos hän haluaa poistaa tai vaihtaa kuvan.