### PR TITLE
Endpointtien korvaamista redux authSlicellä

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,6 +26,7 @@
         "react-redux": "^9.1.2",
         "react-router-dom": "^6.23.0",
         "react-scripts": "5.0.1",
+        "redux-persist": "^6.0.0",
         "typescript": "^4.9.5",
         "uuid": "^10.0.0",
         "web-vitals": "^2.1.4"
@@ -15248,6 +15249,14 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+    },
+    "node_modules/redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "peerDependencies": {
+        "redux": ">4.0.0"
+      }
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "react-redux": "^9.1.2",
     "react-router-dom": "^6.23.0",
     "react-scripts": "5.0.1",
+    "redux-persist": "^6.0.0",
     "typescript": "^4.9.5",
     "uuid": "^10.0.0",
     "web-vitals": "^2.1.4"

--- a/frontend/src/Components/RecipeComments/CommentList/CommentList.tsx
+++ b/frontend/src/Components/RecipeComments/CommentList/CommentList.tsx
@@ -3,6 +3,8 @@ import axios from "axios";
 import { Comment } from "../../../Types/types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faTrash } from "@fortawesome/free-solid-svg-icons";
+import { useSelector } from "react-redux";
+import { RootState } from "../../../Redux/store";
 
 interface CommentListProps {
   recipeId: number;
@@ -10,8 +12,8 @@ interface CommentListProps {
 
 const CommentList: React.FC<CommentListProps> = ({ recipeId }) => {
   const [comments, setComments] = useState<Comment[]>([]);
-  const [currentUserId, setCurrentUserId] = useState<number | null>(null);
   const placeholderImageUrl = "https://via.placeholder.com/40";
+  const user = useSelector((state: RootState) => state.auth.user);
 
   const fetchComments = async () => {
     try {
@@ -21,28 +23,6 @@ const CommentList: React.FC<CommentListProps> = ({ recipeId }) => {
       setComments(response.data);
     } catch (err) {
       console.error("Failed to fetch comments", err);
-    }
-  };
-
-  const fetchCurrentUserId = async () => {
-    try {
-      const token = localStorage.getItem("sessionToken");
-      if (!token) {
-        throw new Error("No token found");
-      }
-
-      const response = await axios.get(
-        `${process.env.REACT_APP_API_BASE_URL}/getUserDetails`,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      );
-      setCurrentUserId(response.data.id);
-      console.log("Current User ID:", response.data.id); // Debugging log
-    } catch (err) {
-      console.error("Failed to fetch current user ID", err);
     }
   };
 
@@ -69,10 +49,9 @@ const CommentList: React.FC<CommentListProps> = ({ recipeId }) => {
 
   useEffect(() => {
     fetchComments();
-    fetchCurrentUserId();
   }, [recipeId]);
 
-  console.log("Comments:", comments); // Debugging log
+  console.log("Comments:", comments);
 
   return (
     <div className="space-y-4">
@@ -95,7 +74,7 @@ const CommentList: React.FC<CommentListProps> = ({ recipeId }) => {
             </div>
             <p className="mt-2">{comment.content}</p>
           </div>
-          {currentUserId === comment.user_id && (
+          {user?.id === comment.user_id && (
             <button
               onClick={() => handleDelete(comment.id)}
               className="absolute top-2 right-2 text-red-500 hover:text-red-600 transition-colors duration-200"

--- a/frontend/src/Pages/ProfilePage/ModifyUserInfo/ModifyUserInfo.tsx
+++ b/frontend/src/Pages/ProfilePage/ModifyUserInfo/ModifyUserInfo.tsx
@@ -1,32 +1,24 @@
 import React, { useState, useEffect } from "react";
-import axios from "axios";
+import { useDispatch, useSelector } from "react-redux";
+import { RootState } from "../../../Redux/store";
+import { updateUserProfile } from "../../../Redux/authSlice";
 import { User } from "../../../Types/types";
 import { useNavigate } from "react-router-dom";
 import ProfilePictureModal from "../../../Components/ProfilePictureModal/ProfilePictureModal";
-import { useDispatch } from "react-redux";
-import { updateUserProfile } from "../../../Redux/authSlice";
+import axios from "axios";
 
 const ModifyUserInfo = () => {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const user = useSelector((state: RootState) => state.auth.user);
   const [userDetails, setUserDetails] = useState<Partial<User> | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const navigate = useNavigate();
-  const dispatch = useDispatch();
 
   useEffect(() => {
-    fetchUserDetails();
-  }, []);
-
-  const fetchUserDetails = async () => {
-    try {
-      const token = localStorage.getItem("sessionToken");
-      const response = await axios.get("/getUserDetails", {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      setUserDetails(response.data);
-    } catch (error) {
-      console.error("Error fetching user details:", error);
+    if (user) {
+      setUserDetails(user);
     }
-  };
+  }, [user]);
 
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>

--- a/frontend/src/Pages/RecipeCreate/RecipeTitle/RecipeTitle.tsx
+++ b/frontend/src/Pages/RecipeCreate/RecipeTitle/RecipeTitle.tsx
@@ -1,7 +1,6 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
-import axios from "axios";
 import {
   setTitle,
   setCategory,
@@ -23,6 +22,7 @@ import {
 
 const RecipeTitle = () => {
   const navigate = useNavigate();
+  const user = useSelector((state: RootState) => state.auth.user);
   const dispatch = useDispatch();
   const recipeState = useSelector((state: RootState) => state.recipe);
   const [errorMessages, setErrorMessages] = useState({
@@ -57,23 +57,6 @@ const RecipeTitle = () => {
       : ""
   );
 
-  useEffect(() => {
-    const token = localStorage.getItem("sessionToken");
-    if (token) {
-      axios
-        .get(`${process.env.REACT_APP_API_BASE_URL}/getUserDetails`, {
-          headers: { Authorization: `Bearer ${token}` },
-        })
-        .then((response) => {
-          const user_id = response.data.id;
-          dispatch(setuser_id(user_id));
-        })
-        .catch((error) => {
-          console.error("Error fetching user details", error);
-        });
-    }
-  }, [dispatch]);
-
   const handleButtonClick = () => {
     const errors = {
       title: validateTitle(title),
@@ -95,6 +78,9 @@ const RecipeTitle = () => {
       dispatch(setsecondary_category(secondary_category));
       dispatch(setMainIngredient(specificIngredient));
       dispatch(setMainIngredientCategory(mainCategory));
+      if (user && user.id !== undefined) {
+        dispatch(setuser_id(user.id.toString()));
+      }
       console.log(recipeState);
       navigate("/create-recipe/recipe-ingredients");
     }

--- a/frontend/src/Redux/store.ts
+++ b/frontend/src/Redux/store.ts
@@ -1,13 +1,24 @@
 import { configureStore } from "@reduxjs/toolkit";
+import { persistStore, persistReducer } from "redux-persist";
+import storage from "redux-persist/lib/storage";
 import recipeReducer from "./recipeSlice";
 import authReducer from "./authSlice";
+
+const persistConfig = {
+  key: "root",
+  storage,
+};
+
+const persistedAuthReducer = persistReducer(persistConfig, authReducer);
 
 export const store = configureStore({
   reducer: {
     recipe: recipeReducer,
-    auth: authReducer,
+    auth: persistedAuthReducer,
   },
 });
+
+export const persistor = persistStore(store);
 
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;

--- a/frontend/src/Types/types.tsx
+++ b/frontend/src/Types/types.tsx
@@ -22,6 +22,7 @@ export interface Ingredient {
 
 export interface User {
   email: string;
+  id?: number;
   nickname: string;
   bio: string;
   location: string;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -4,7 +4,8 @@ import "./tailwind.css";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
 import { Provider } from "react-redux";
-import { store } from "./Redux/store";
+import { store, persistor } from "./Redux/store";
+import { PersistGate } from "redux-persist/integration/react";
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
@@ -12,7 +13,9 @@ const root = ReactDOM.createRoot(
 root.render(
   <React.StrictMode>
     <Provider store={store}>
-      <App />
+      <PersistGate loading={null} persistor={persistor}>
+        <App />
+      </PersistGate>
     </Provider>
   </React.StrictMode>
 );


### PR DESCRIPTION
Closes #93 

Korvasin `/getUserDetails`-endpointin käytön seuraavissa tiedostoissa:

- **RecipeTitle.tsx**
- **CommentList.tsx**
- **ModifyUserInfo.tsx**

Käytän näissä tiedostoissa Reduxin **authSlice**-toiminnallisuutta käyttäjätietojen hallintaan.

Asensimme ja otimme käyttöön **Redux Persistin**, jotta Redux-tilan säilyttäminen sivun päivitysten välillä olisi mahdollista. Redux Persist tallentaa Redux-tilan selaimen localStorageen (tai muuhun tallennusmoottoriin) ja lataa sen uudelleen, kun sovellus käynnistyy. Näin käyttäjän tiedot ja muut tilat säilyvät sivun päivityksissä.