### PR TITLE
Navbar, LikedRecipes ja UserRecipes tyylikorjauksia

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import * as ROUTES from "../src/Constants/routes";
-// import TestComponent from './Components/TestComponent/dbtest';
 import Frontpage from "./Pages/Frontpage/frontpage";
 import Register from "./Pages/Register/Register/Register";
 import Login from "./Pages/Login/Login";
@@ -21,7 +20,7 @@ function App() {
     <Router>
       <div id="root">
         <Navbar />
-        <main>
+        <main className="pt-16">
           <Routes>
             <Route path={ROUTES.LANDING} element={<Frontpage />} />
             <Route path={ROUTES.REGISTER + "/*"} element={<RegisterRoute />} />

--- a/frontend/src/Components/LikedRecipes/LikedRecipes.tsx
+++ b/frontend/src/Components/LikedRecipes/LikedRecipes.tsx
@@ -3,8 +3,12 @@ import axios from "axios";
 import { RecipeState } from "../../Types/types";
 import { Link } from "react-router-dom";
 
+const placeholderImageUrl = "https://via.placeholder.com/150";
+
 const LikedRecipes = () => {
   const [likedRecipes, setLikedRecipes] = useState<RecipeState[]>([]);
+  const [currentPage, setCurrentPage] = useState(1);
+  const recipesPerPage = 9;
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
@@ -33,30 +37,60 @@ const LikedRecipes = () => {
     }
   };
 
+  const loadMoreRecipes = () => {
+    setCurrentPage((prevPage) => prevPage + 1);
+  };
+
+  const displayedRecipes = likedRecipes.slice(0, currentPage * recipesPerPage);
+
   if (loading)
     return <div className="text-center text-gray-500">Loading...</div>;
   if (error)
     return <div className="text-center text-red-500">Error: {error}</div>;
 
   return (
-    <div className="max-w-4xl mx-auto p-4">
+    <div className="max-w-4xl mx-auto">
       <h2 className="text-2xl font-bold mb-4">Hyväksihavaitut herkut</h2>
       {likedRecipes.length > 0 ? (
-        <ul className="space-y-4">
-          {likedRecipes.map((recipe) => (
-            <li key={recipe.id} className="bg-white shadow-md rounded-lg p-4">
+        <>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {displayedRecipes.map((recipe) => (
               <Link
                 to={`/recipe/${recipe.id}`}
-                className="text-lg font-semibold text-blue-500 hover:underline"
+                key={recipe.id}
+                className="block"
               >
-                {recipe.title} - {recipe.category}
+                <div className="bg-white rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow duration-200">
+                  <img
+                    src={
+                      recipe.picture_url
+                        ? `${process.env.REACT_APP_API_BASE_URL}/recipePicture/${recipe.picture_url}`
+                        : placeholderImageUrl
+                    }
+                    alt={recipe.title}
+                    className="w-full h-48 object-cover"
+                  />
+                  <div className="p-4">
+                    <h3 className="text-lg font-semibold">{recipe.title}</h3>
+                  </div>
+                </div>
               </Link>
-            </li>
-          ))}
-        </ul>
+            ))}
+          </div>
+          {displayedRecipes.length < likedRecipes.length && (
+            <div className="text-center mt-4">
+              <button
+                onClick={loadMoreRecipes}
+                className="bg-blue-500 text-white p-2 rounded"
+              >
+                Näytä lisää reseptejä
+              </button>
+            </div>
+          )}
+        </>
       ) : (
         <p className="text-center text-gray-500">
-          Tyhjä herkkulista – aloita tykkääminen!
+          Reseptejä ei löydy, vielä...
         </p>
       )}
     </div>

--- a/frontend/src/Components/Navbar/Navbar.tsx
+++ b/frontend/src/Components/Navbar/Navbar.tsx
@@ -74,7 +74,7 @@ const Navbar = () => {
 
   if (!isLoggedIn) {
     return (
-      <nav className="bg-gray-800 p-4 flex justify-between items-center">
+      <nav className="fixed top-0 left-0 w-full bg-gray-800 p-4 flex justify-between items-center z-50">
         <button onClick={() => navigate("/")}>
           <img
             src="https://via.placeholder.com/40"
@@ -105,7 +105,7 @@ const Navbar = () => {
   }
 
   return (
-    <nav className="bg-gray-800 p-4 flex justify-between items-center">
+    <nav className="fixed top-0 left-0 w-full bg-gray-800 p-4 flex justify-between items-center z-50">
       <button onClick={() => navigate("/")}>
         <img src="https://via.placeholder.com/40" alt="Logo" className="h-10" />
       </button>

--- a/frontend/src/Components/UserRecipes/UserRecipes.tsx
+++ b/frontend/src/Components/UserRecipes/UserRecipes.tsx
@@ -3,8 +3,12 @@ import axios from "axios";
 import { RecipeState } from "../../Types/types";
 import { Link } from "react-router-dom";
 
+const placeholderImageUrl = "https://via.placeholder.com/150";
+
 const UserRecipes = () => {
   const [recipes, setRecipes] = useState<RecipeState[]>([]);
+  const [currentPage, setCurrentPage] = useState(1);
+  const recipesPerPage = 9;
 
   useEffect(() => {
     fetchUserRecipes();
@@ -28,22 +32,52 @@ const UserRecipes = () => {
     }
   };
 
+  const loadMoreRecipes = () => {
+    setCurrentPage((prevPage) => prevPage + 1);
+  };
+
+  const displayedRecipes = recipes.slice(0, currentPage * recipesPerPage);
+
   return (
-    <div className="max-w-4xl mx-auto p-4">
+    <div className="max-w-4xl mx-auto">
       <h2 className="text-2xl font-bold mb-4">Reseptikokoelmasi</h2>
       {recipes.length > 0 ? (
-        <ul className="space-y-4">
-          {recipes.map((recipe) => (
-            <li key={recipe.id} className="bg-white shadow-md rounded-lg p-4">
+        <>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {displayedRecipes.map((recipe) => (
               <Link
                 to={`/recipe/${recipe.id}`}
-                className="text-lg font-semibold text-blue-500 hover:underline"
+                key={recipe.id}
+                className="block"
               >
-                {recipe.title} - {recipe.category}
+                <div className="bg-white rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow duration-200">
+                  <img
+                    src={
+                      recipe.picture_url
+                        ? `${process.env.REACT_APP_API_BASE_URL}/recipePicture/${recipe.picture_url}`
+                        : placeholderImageUrl
+                    }
+                    alt={recipe.title}
+                    className="w-full h-48 object-cover"
+                  />
+                  <div className="p-4">
+                    <h3 className="text-lg font-semibold">{recipe.title}</h3>
+                  </div>
+                </div>
               </Link>
-            </li>
-          ))}
-        </ul>
+            ))}
+          </div>
+          {displayedRecipes.length < recipes.length && (
+            <div className="text-center mt-4">
+              <button
+                onClick={loadMoreRecipes}
+                className="bg-blue-500 text-white p-2 rounded"
+              >
+                Näytä lisää reseptejä
+              </button>
+            </div>
+          )}
+        </>
       ) : (
         <p className="text-center text-gray-500">
           Reseptejä ei löydy, vielä...

--- a/frontend/src/Pages/ProfilePage/ProfileView/ProfileView.tsx
+++ b/frontend/src/Pages/ProfilePage/ProfileView/ProfileView.tsx
@@ -84,7 +84,9 @@ const ProfileView = () => {
         Muokkaa profiilia
       </button>
       <UserRecipes />
-      <LikedRecipes />
+      <div className="my-20">
+        <LikedRecipes />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
Closes #107
Closes #108

Päivitetty Navbar-komponentti pysymään kiinteästi näytön yläreunassa, varmistaen, että se on aina näkyvissä, vaikka käyttäjä vierittää sivua alaspäin.

Parannettu UserRecipes ja LikedRecipes -komponenttien tyyliä näyttämään kunkin reseptin kuva ja nimi. Toteutettu sivutus, joka renderöi 9 reseptiä kerrallaan. Jos reseptejä on enemmän kuin 9, tarjotaan "Näytä lisää" -painike seuraavien reseptien näyttämiseksi.