### PR TITLE
Toisten käyttäjien profiilin katselmointi

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -157,6 +157,10 @@ app.delete(
   (req, res) => userController.deleteAccount(req, res)
 );
 
+app.get("/user/:id", (req, res) =>
+  userController.getPublicUserDetails(req, res)
+);
+
 // Recipe routes below this line ----------------------------
 
 app.post("/recipeCreate", upload.single("file"), (req, res) =>
@@ -228,6 +232,16 @@ app.get(
     }
   }
 );
+
+app.get("/user/:userId/recipes", async (req, res) => {
+  const { userId } = req.params;
+  try {
+    const recipes = await recipeController.getUserRecipes(Number(userId));
+    res.json(recipes);
+  } catch (error) {
+    res.status(500).json({ message: "Error fetching user recipes" });
+  }
+});
 
 app.post(
   "/likeRecipe/:id",

--- a/backend/src/controllers/UserController.ts
+++ b/backend/src/controllers/UserController.ts
@@ -221,6 +221,18 @@ class UserController {
       res.status(200).json({ message: "Logged out successfully" });
     });
   }
+
+  async getPublicUserDetails(req: any, res: any) {
+    const { id } = req.params;
+    try {
+      const userDetails = await this.userService.getPublicUserDetails(
+        Number(id)
+      );
+      res.json(userDetails);
+    } catch (error) {
+      res.status(500).json({ message: "Error fetching user details" });
+    }
+  }
 }
 
 export default UserController;

--- a/backend/src/repositories/UserRepository.ts
+++ b/backend/src/repositories/UserRepository.ts
@@ -181,6 +181,34 @@ class UserRepository {
     const result = await pool.query(query);
     return (result.rowCount ?? 0) > 0;
   }
+
+  async findPublicById(id: number) {
+    const client = await pool.connect();
+    try {
+      const result = await client.query(
+        `
+        SELECT 
+          users.id, 
+          users.nickname, 
+          users.bio, 
+          users.location, 
+          users.instagram, 
+          users.tiktok, 
+          users.experience_level, 
+          profile_pictures.id AS profile_picture_id, 
+          profile_pictures.type AS profile_picture_type, 
+          profile_pictures.data AS profile_picture_data 
+        FROM users 
+        LEFT JOIN profile_pictures ON users.id = profile_pictures.user_id 
+        WHERE users.id = $1
+      `,
+        [id]
+      );
+      return result.rows[0]; // Return the user with the given id and profile picture info
+    } finally {
+      client.release();
+    }
+  }
 }
 
 export default UserRepository;

--- a/backend/src/services/UserService.ts
+++ b/backend/src/services/UserService.ts
@@ -87,6 +87,10 @@ class UserService {
   async deleteAccount(userId: number) {
     return this.userRepository.deleteAccount(userId);
   }
+
+  async getPublicUserDetails(id: number) {
+    return await this.userRepository.findPublicById(id);
+  }
 }
 
 export default UserService;

--- a/frontend/src/Components/UserRecipes/UserRecipes.tsx
+++ b/frontend/src/Components/UserRecipes/UserRecipes.tsx
@@ -5,26 +5,23 @@ import { Link } from "react-router-dom";
 
 const placeholderImageUrl = "https://via.placeholder.com/150";
 
-const UserRecipes = () => {
+interface UserRecipesProps {
+  userId: string;
+}
+
+const UserRecipes: React.FC<UserRecipesProps> = ({ userId }) => {
   const [recipes, setRecipes] = useState<RecipeState[]>([]);
   const [currentPage, setCurrentPage] = useState(1);
   const recipesPerPage = 9;
 
   useEffect(() => {
     fetchUserRecipes();
-  }, []);
+  }, [userId]);
 
   const fetchUserRecipes = async () => {
     try {
-      const token = localStorage.getItem("sessionToken");
-      if (!token) {
-        throw new Error("No token found");
-      }
       const response = await axios.get(
-        `${process.env.REACT_APP_API_BASE_URL}/getUserRecipes`,
-        {
-          headers: { Authorization: `Bearer ${token}` },
-        }
+        `${process.env.REACT_APP_API_BASE_URL}/user/${userId}/recipes`
       );
       setRecipes(response.data);
     } catch (error) {
@@ -40,7 +37,7 @@ const UserRecipes = () => {
 
   return (
     <div className="max-w-4xl mx-auto">
-      <h2 className="text-2xl font-bold mb-4">Reseptikokoelmasi</h2>
+      <h2 className="text-2xl font-bold mb-4">Reseptikokoelma</h2>
       {recipes.length > 0 ? (
         <>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">

--- a/frontend/src/Pages/ProfilePage/OtherUserProfileView/OtherUserProfileView.tsx
+++ b/frontend/src/Pages/ProfilePage/OtherUserProfileView/OtherUserProfileView.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from "react";
+import axios from "axios";
+import { useParams } from "react-router-dom";
+import UserRecipes from "../../../Components/UserRecipes/UserRecipes";
+import "../../../Styles/loadingAnimation.css";
+
+const OtherUserProfileView = () => {
+  const { userId } = useParams<{ userId: string }>();
+  const [profile, setProfile] = useState<any>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchProfile = async () => {
+      try {
+        const response = await axios.get(
+          `${process.env.REACT_APP_API_BASE_URL}/user/${userId}`
+        );
+        setProfile(response.data);
+      } catch (error) {
+        console.error("Error fetching profile:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    if (userId) {
+      fetchProfile();
+    }
+  }, [userId]);
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100">
+        <div className="loader"></div>
+        <p className="mt-4 text-lg text-gray-700">Ladataan...</p>
+      </div>
+    );
+  }
+
+  if (!profile) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100">
+        <p className="mt-4 text-lg text-gray-700">Profiilia ei löytynyt.</p>
+      </div>
+    );
+  }
+
+  const profilePicture = profile.profile_picture_data
+    ? `data:${profile.profile_picture_type};base64,${btoa(
+        new Uint8Array(profile.profile_picture_data.data).reduce(
+          (data, byte) => data + String.fromCharCode(byte),
+          ""
+        )
+      )}`
+    : "/placeholder-user.png";
+
+  return (
+    <div className="max-w-4xl mx-auto p-4">
+      {profilePicture && (
+        <img
+          src={profilePicture}
+          alt="Profile"
+          className="w-32 h-32 rounded-full mx-auto mb-6 border-4 border-gray-300"
+        />
+      )}
+      <div className="bg-white shadow-md rounded-lg p-6 mb-6">
+        <p className="text-lg font-semibold mb-2">
+          Käyttäjänimi: {profile.nickname}
+        </p>
+        <p className="text-lg mb-2">Bio: {profile.bio}</p>
+        <p className="text-lg mb-2">Sijainti: {profile.location}</p>
+        <p className="text-lg mb-2">Instagram: {profile.instagram}</p>
+        <p className="text-lg mb-2">TikTok: {profile.tiktok}</p>
+        <p className="text-lg mb-2">Kokkitasosi: {profile.experience_level}</p>
+      </div>
+      {userId && <UserRecipes userId={userId} />}
+    </div>
+  );
+};
+
+export default OtherUserProfileView;

--- a/frontend/src/Pages/ProfilePage/ProfilePage.tsx
+++ b/frontend/src/Pages/ProfilePage/ProfilePage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { Routes, Route, Navigate, useNavigate } from "react-router-dom";
 import ProfileView from "./ProfileView/ProfileView";
 import ModifyUserInfo from "./ModifyUserInfo/ModifyUserInfo";
+import OtherUserProfileView from "./OtherUserProfileView/OtherUserProfileView";
 import { useSelector } from "react-redux";
 import { RootState } from "../../Redux/store";
 import "../../Styles/loadingAnimation.css";
@@ -61,6 +62,7 @@ const ProfilePage = () => {
         <Route path="/" element={<Navigate to="view" />} />
         <Route path="view" element={<ProfileView />} />
         <Route path="modify" element={<ModifyUserInfo />} />
+        <Route path="user/:userId" element={<OtherUserProfileView />} />
       </Routes>
     </div>
   );

--- a/frontend/src/Pages/ProfilePage/ProfileView/ProfileView.tsx
+++ b/frontend/src/Pages/ProfilePage/ProfileView/ProfileView.tsx
@@ -120,7 +120,7 @@ const ProfileView = () => {
           Poista tili
         </button>
       </div>
-      <UserRecipes />
+      <UserRecipes userId={user?.id?.toString() || ""} />
       <div className="my-20">
         <LikedRecipes />
       </div>

--- a/frontend/src/Pages/RecipeDetails/RecipeDetails.tsx
+++ b/frontend/src/Pages/RecipeDetails/RecipeDetails.tsx
@@ -8,6 +8,8 @@ import LikeButton from "../../Components/LikeButton/LikeButton";
 import AddComment from "../../Components/RecipeComments/AddComment/AddComment";
 import CommentList from "../../Components/RecipeComments/CommentList/CommentList";
 import ConfirmModal from "../../Components/Modal/ConfirmModal/ConfirmModal";
+import { faUser } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 const placeholderImageUrl = "https://via.placeholder.com/150";
 
@@ -101,7 +103,11 @@ const RecipeDetails = () => {
               <div key={index} className="ml-1">{`${index + 1}. ${step}`}</div>
             ))}
           </div>
-          <p className="mb-4 font-semibold">
+          <p
+            className="mb-4 font-semibold cursor-pointer text-blue-500 hover:bg-blue-100 transition duration-200 inline-flex items-center"
+            onClick={() => navigate(`/profile/user/${recipe.user_id}`)}
+          >
+            <FontAwesomeIcon icon={faUser} className="mr-2" />
             Keittiökynäilijä {recipe.nickname}
           </p>
           <LikeButton recipeId={recipe.id || ""} />


### PR DESCRIPTION
Closes #118

Backend:

- Lisätty kaksi uutta endpointia käyttäjätietojen ja reseptien hakemiseen ilman JWT-tunnistautumista.
  - `/user/:id`: Hakee käyttäjän julkiset tiedot ilman salasanaa ja sähköpostia. Sisältää myös profiilikuvan.
  - `/user/:userId/recipes`: Hakee käyttäjän reseptit käyttäjän ID:n perusteella ilman JWT-tunnistautumista.

Frontend:

- Lisätty uusi sivu `OtherUserProfileView.tsx` ja reitti tälle `ProfilePage.tsx`-tiedostoon.
- Muokattu `UserRecipes`-komponenttia käyttämään `userId`-proppia.
- Muokattu `ProfileView.tsx`-tiedostoa käyttämään `UserRecipes`-komponenttia `userId`-propin kanssa.
- Lisätty navigointi `RecipeDetails.tsx`-tiedostoon, jotta käyttäjät voivat nähdä muiden käyttäjien profiilit.