### PR TITLE
Peruuta reseptin muokkaaminen nappula

### DIFF
--- a/frontend/src/Components/Navbar/Navbar.tsx
+++ b/frontend/src/Components/Navbar/Navbar.tsx
@@ -77,7 +77,7 @@ const Navbar = () => {
     return (
       <nav className="navbar fixed top-0 left-0 w-full bg-gray-800 p-4 flex justify-between items-center z-50">
         <button onClick={() => navigate("/")}>
-          <img src="recipeLogo.webp" alt="Logo" className="logo" />
+          <img src="/recipeLogo.webp" alt="Logo" className="logo" />
         </button>
         <div className="flex space-x-4">
           <button
@@ -104,7 +104,7 @@ const Navbar = () => {
   return (
     <nav className="navbar fixed top-0 left-0 w-full bg-gray-800 p-4 flex justify-between items-center z-50">
       <button onClick={() => navigate("/")}>
-        <img src="recipeLogo.webp" alt="Logo" className="logo" />
+        <img src="/recipeLogo.webp" alt="Logo" className="logo" />
       </button>
       <div className="flex space-x-4">
         <button

--- a/frontend/src/Pages/RecipeCreate/RecipeCreate.tsx
+++ b/frontend/src/Pages/RecipeCreate/RecipeCreate.tsx
@@ -71,6 +71,14 @@ const CreateRecipe: React.FC<CreateRecipeProps> = ({ mode, recipeId }) => {
     }
   };
 
+  const handleCancel = () => {
+    if (mode === "edit" && recipeId) {
+      navigate(`/recipe/${recipeId}`);
+    } else {
+      navigate("/");
+    }
+  };
+
   if (isLoading) {
     return (
       <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100">
@@ -113,7 +121,7 @@ const CreateRecipe: React.FC<CreateRecipeProps> = ({ mode, recipeId }) => {
   }
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100">
+    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100 pt-16">
       <div className="w-full max-w-4xl p-4">
         <Routes>
           <Route path="/" element={<Navigate to="recipe-title" />} />
@@ -126,6 +134,16 @@ const CreateRecipe: React.FC<CreateRecipeProps> = ({ mode, recipeId }) => {
           />
           <Route path="recipe-created" element={<RecipeCreated />} />
         </Routes>
+        {mode === "edit" && (
+          <div className="flex justify-center mt-4">
+            <button
+              onClick={handleCancel}
+              className="px-4 py-2 text-white bg-red-500 rounded hover:bg-red-700"
+            >
+              Peruuta reseptin muokkaaminen
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/Pages/RecipeCreate/RecipeIngredients/RecipeIngredients.tsx
+++ b/frontend/src/Pages/RecipeCreate/RecipeIngredients/RecipeIngredients.tsx
@@ -208,7 +208,7 @@ const RecipeIngredients = () => {
   console.log("Recipe State in RecipeIngredients:", recipeState);
 
   return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-100">
+    <div className="flex items-center justify-center min-h-fit bg-gray-100">
       <div className="bg-white p-3 rounded shadow-md w-full max-w-4xl">
         <ProgressBar currentStep={2} maxStep={4} />
         <p className="mb-4 text-2xl font-semibold text-gray-700">

--- a/frontend/src/Pages/RecipeCreate/RecipeOverview/RecipeOverview.tsx
+++ b/frontend/src/Pages/RecipeCreate/RecipeOverview/RecipeOverview.tsx
@@ -151,7 +151,7 @@ const RecipeOverview: React.FC<RecipeOverviewProps> = ({ mode, recipeId }) => {
   console.log(recipeState);
 
   return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-100">
+    <div className="flex items-center justify-center min-h-fit bg-gray-100">
       <div className="bg-white p-8 rounded shadow-md w-full max-w-lg">
         <ProgressBar currentStep={4} maxStep={4} />
         <p className="mb-4 text-2xl font-semibold text-gray-700">

--- a/frontend/src/Pages/RecipeCreate/RecipePicture/RecipePicture.tsx
+++ b/frontend/src/Pages/RecipeCreate/RecipePicture/RecipePicture.tsx
@@ -108,7 +108,7 @@ const RecipePicture = () => {
   console.log("Recipe State in RecipePicture:", recipeState);
 
   return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-100">
+    <div className="flex items-center justify-center min-h-fit bg-gray-100">
       <div className="bg-white p-8 rounded shadow-md w-full max-w-xl">
         <ProgressBar currentStep={3} maxStep={4} />
         <p className="mb-4 text-2xl font-semibold text-gray-700">

--- a/frontend/src/Pages/RecipeCreate/RecipeTitle/RecipeTitle.tsx
+++ b/frontend/src/Pages/RecipeCreate/RecipeTitle/RecipeTitle.tsx
@@ -213,7 +213,7 @@ const RecipeTitle = () => {
   ];
 
   return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-100">
+    <div className="flex items-center justify-center min-h-fit bg-gray-100">
       <div className="bg-white p-8 rounded shadow-md w-full max-w-md">
         <ProgressBar currentStep={1} maxStep={4} />
         <p className="mb-4 text-2xl font-semibold text-gray-700">


### PR DESCRIPTION
Closes #146 

- Lisätty "Peruuta reseptin muokkaaminen" -nappula, jolla käyttäjä voi palata takaisin reseptiin, jota oltiin muokkaamassa.
- Säädetty nappulan sijaintia muokkaamalla `min-h-screen` -> `min-h-fit` komponenteissa, jotta vältetään suuret välit ja nappula on lähempänä sisältöä.
- Korjattiin myös navbar.tsx tiedostossa logon url, jotta se toimii aina.