### PR TITLE
Reseptihaun sivustus

### DIFF
--- a/backend/src/controllers/RecipeController.ts
+++ b/backend/src/controllers/RecipeController.ts
@@ -84,16 +84,22 @@ class RecipeController {
   };
 
   async searchRecipes(req: Request, res: Response) {
+    const { query } = req.query;
+    const { page = 1, limit = 9 } = req.query;
+
     try {
-      const { query } = req.query;
-      if (!query || typeof query !== "string") {
-        return res.status(400).send("Query parameter is required");
-      }
-      const recipes = await this.recipeService.searchRecipes(query);
-      res.json(recipes);
+      const recipes = await this.recipeService.getRecipes(
+        String(query),
+        Number(page),
+        Number(limit)
+      );
+      const totalRecipes = await this.recipeService.getTotalRecipes(
+        String(query)
+      );
+      res.status(200).json({ recipes, totalRecipes });
     } catch (error) {
-      console.error(error);
-      res.status(500).send("An error occurred while searching for recipes");
+      console.error("Error fetching recipes:", error);
+      res.status(500).json({ message: "Error fetching recipes" });
     }
   }
 

--- a/backend/src/repositories/RecipeRepository.ts
+++ b/backend/src/repositories/RecipeRepository.ts
@@ -291,6 +291,39 @@ class RecipeRepository {
     }
   }
 
+  async getRecipes(searchTerm: string, page: number, limit: number) {
+    const offset = (page - 1) * limit;
+    const query: QueryConfig = {
+      text: `
+        SELECT r.id, r.title, r.picture_url
+        FROM recipes r
+        WHERE r.title ILIKE $1
+          OR r.category ILIKE $1
+          OR r.secondary_category ILIKE $1
+        ORDER BY r.created_at DESC
+        LIMIT $2 OFFSET $3
+      `,
+      values: [`%${searchTerm}%`, limit, offset],
+    };
+    const result = await pool.query(query);
+    return result.rows;
+  }
+
+  async getTotalRecipes(searchTerm: string) {
+    const query: QueryConfig = {
+      text: `
+        SELECT COUNT(*) 
+        FROM recipes 
+        WHERE title ILIKE $1
+          OR category ILIKE $1
+          OR secondary_category ILIKE $1
+      `,
+      values: [`%${searchTerm}%`],
+    };
+    const result = await pool.query(query);
+    return parseInt(result.rows[0].count, 10);
+  }
+
   async getRandomRecipeId(): Promise<number | null> {
     const query = {
       text: "SELECT id FROM recipes ORDER BY RANDOM() LIMIT 1",

--- a/backend/src/services/RecipeService.ts
+++ b/backend/src/services/RecipeService.ts
@@ -75,6 +75,14 @@ class RecipeService {
     return this.recipeRepository.searchByIngredientOrName(searchTerm);
   }
 
+  async getRecipes(searchTerm: string, page: number, limit: number) {
+    return this.recipeRepository.getRecipes(searchTerm, page, limit);
+  }
+
+  async getTotalRecipes(searchTerm: string) {
+    return this.recipeRepository.getTotalRecipes(searchTerm);
+  }
+
   async getRecipeById(id: number): Promise<Recipe | null> {
     return this.recipeRepository.getRecipeById(id);
   }

--- a/frontend/src/Components/CategorySelection/CategorySelection.tsx
+++ b/frontend/src/Components/CategorySelection/CategorySelection.tsx
@@ -40,9 +40,15 @@ const CategorySelection = () => {
       const response = await axios.get(
         `${
           process.env.REACT_APP_API_BASE_URL
-        }/search?query=${encodeURIComponent(category)}`
+        }/search?query=${encodeURIComponent(category)}&page=1&limit=9`
       );
-      navigate(SEARCH_RESULTS, { state: { recipes: response.data } });
+      navigate(SEARCH_RESULTS, {
+        state: {
+          recipes: response.data.recipes,
+          totalRecipes: response.data.totalRecipes,
+          searchTerm: category,
+        },
+      });
     } catch (error) {
       console.error("Error fetching recipes:", error);
     }

--- a/frontend/src/Components/RecipeSearch/RecipeSearch.tsx
+++ b/frontend/src/Components/RecipeSearch/RecipeSearch.tsx
@@ -5,7 +5,6 @@ import * as ROUTES from "../../Constants/routes";
 
 function RecipeSearch() {
   const [searchTerm, setSearchTerm] = useState("");
-  const [recipes, setRecipes] = useState<{ id: number; title: string }[]>([]);
   const [error, setError] = useState("");
 
   const navigate = useNavigate();
@@ -15,9 +14,15 @@ function RecipeSearch() {
     setError("");
     try {
       const response = await axios.get(
-        `/search?query=${encodeURIComponent(searchTerm)}`
+        `/search?query=${encodeURIComponent(searchTerm)}&page=1&limit=9`
       );
-      navigate(ROUTES.SEARCH_RESULTS, { state: { recipes: response.data } });
+      navigate(ROUTES.SEARCH_RESULTS, {
+        state: {
+          recipes: response.data.recipes,
+          totalRecipes: response.data.totalRecipes,
+          searchTerm,
+        },
+      });
     } catch (error) {
       console.error("Search failed:", error);
       setError("Failed to fetch recipes. Please try again.");


### PR DESCRIPTION
Closes #157 

### Backend:

- Lisätty metodit hakemaan sivutettuja reseptejä ja kokonaismäärää.
- Päivitetty SQL-kyselyt sisältämään haun otsikon, kategorian ja toissijaisen kategorian perusteella.

### Frontend:

**CategorySelection**
- Päivitetty `handleCategoryClick` hakemaan ensimmäinen sivu tuloksista, joissa on enintään 9 reseptiä per sivu.
- Navigoi `SEARCH_RESULTS`-sivulle haettujen reseptien, kokonaismäärän ja hakutermin kanssa.

**RecipeSearch**
- Päivitetty `handleSearch` hakemaan ensimmäinen sivu tuloksista, joissa on enintään 9 reseptiä per sivu.
- Navigoi `SEARCH_RESULTS`-sivulle haettujen reseptien, kokonaismäärän ja hakutermin kanssa.

**RecipeSearchResults**
- Toteutettu sivutus käyttämällä MUI Pagination -komponenttia.
- Päivitetty hakemaan reseptejä nykyisen sivun perusteella.
- Säilytetty sivutuksen tila, kun navigoidaan takaisin reseptistä.
